### PR TITLE
Do not store Go pointers in C structs

### DIFF
--- a/librsync/librsync_callback.go
+++ b/librsync/librsync_callback.go
@@ -3,6 +3,7 @@ package librsync
 /*
 #include <stdio.h>
 #include <librsync.h>
+#include <stdlib.h>
 */
 import "C"
 
@@ -12,20 +13,25 @@ import (
 )
 
 //export patchCallbackGo
-func patchCallbackGo(_patcher uintptr, pos C.rs_long_t, len *C.size_t, _buf *unsafe.Pointer) C.rs_result {
+func patchCallbackGo(_patcher uintptr, pos C.rs_long_t, buflen *C.size_t, buf *unsafe.Pointer) C.rs_result {
 	patcher := getPatcher(_patcher)
 
-	patcher.buf = make([]byte, int(*len))
-	n, err := patcher.basis.ReadAt(patcher.buf, int64(pos))
-	if n < int(*len) {
+	if patcher.buf != nil {
+		C.free(patcher.buf)
+	}
+	patcher.buf = C.malloc(*buflen)
+	// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
+	s := (*[1 << 30]byte)(patcher.buf)[:*buflen:*buflen]
+	n, err := patcher.basis.ReadAt(s, int64(pos))
+	if n < int(*buflen) {
 		if err != io.EOF {
 			panic(jobInternalPanic{err})
 		} else {
 			return C.RS_INPUT_ENDED
 		}
 	}
-	*len = C.size_t(n)
-	*_buf = unsafe.Pointer(&(patcher.buf[0]))
+	*buflen = C.size_t(n)
+	*buf = patcher.buf
 
 	return C.RS_DONE
 }


### PR DESCRIPTION
With Go 1.7, the rules around passing pointers from/to C are even stricter. See e.g. [this bug](https://github.com/golang/go/issues/16778).

When running Go 1.7, this would work before the patch:

    go test

But more strict checking fails:

    GODEBUG=cgocheck=2 go test

This is fixed with this pull request.
There appear to be more problems in my application seemingly related to golibrsync (`fatal error: sweep increased allocation count`), but I haven't tracked them down yet.